### PR TITLE
Stop tracking transaction IDs

### DIFF
--- a/alloctxn/alloctxn.go
+++ b/alloctxn/alloctxn.go
@@ -41,8 +41,9 @@ func Begin(super *super.FsSuper, txn *txn.Txn, balloc *alloc.Alloc, ialloc *allo
 	return atxn
 }
 
-func (atxn *AllocTxn) Id() txn.TransId {
-	return atxn.Buftxn.Id
+// Id returns a pointer to the BufTxn for debug printing only
+func (atxn *AllocTxn) Id() *buftxn.BufTxn {
+	return atxn.Buftxn
 }
 
 func (atxn *AllocTxn) AllocINum() common.Inum {

--- a/buftxn/buftxn.go
+++ b/buftxn/buftxn.go
@@ -37,7 +37,6 @@ import (
 type BufTxn struct {
 	txn  *txn.Txn
 	bufs *buf.BufMap // map of bufs read/written by this transaction
-	Id   txn.TransId
 }
 
 // Start a local transaction with no writes from a global Txn manager.
@@ -45,9 +44,8 @@ func Begin(txn *txn.Txn) *BufTxn {
 	trans := &BufTxn{
 		txn:  txn,
 		bufs: buf.MkBufMap(),
-		Id:   txn.GetTransId(),
 	}
-	util.DPrintf(1, "Begin: %v\n", trans.Id)
+	util.DPrintf(1, "Begin: %v\n", trans)
 	return trans
 }
 
@@ -107,8 +105,8 @@ func (buftxn *BufTxn) LogSzBytes() uint64 {
 // wait=false is an asynchronous commit, which can be made durable later with
 // Flush.
 func (buftxn *BufTxn) CommitWait(wait bool) bool {
-	util.DPrintf(1, "Commit %d w %v\n", buftxn.Id, wait)
-	ok := buftxn.txn.CommitWait(buftxn.bufs.DirtyBufs(), wait, buftxn.Id)
+	util.DPrintf(1, "Commit %p w %v\n", buftxn, wait)
+	ok := buftxn.txn.CommitWait(buftxn.bufs.DirtyBufs(), wait)
 	return ok
 }
 

--- a/fstxn/fstxn.go
+++ b/fstxn/fstxn.go
@@ -75,11 +75,11 @@ func (op *FsTxn) AllocInode(kind nfstypes.Ftype3) *inode.Inode {
 func (op *FsTxn) ReleaseInode(ip *inode.Inode) {
 	util.DPrintf(1, "ReleaseInode %v\n", ip)
 	op.doneInode(ip)
-	op.Fs.Lockmap.Release(ip.Inum, op.Atxn.Id())
+	op.Fs.Lockmap.Release(ip.Inum)
 }
 
 func (op *FsTxn) LockInode(inum common.Inum) *cache.Cslot {
-	op.Fs.Lockmap.Acquire(inum, op.Atxn.Id())
+	op.Fs.Lockmap.Acquire(inum)
 	cslot := op.Fs.Icache.LookupSlot(uint64(inum))
 	if cslot == nil {
 		panic("GetInodeLocked")
@@ -98,7 +98,7 @@ func (op *FsTxn) GetInodeLocked(inum common.Inum) *inode.Inode {
 	}
 	ip := cslot.Obj.(*inode.Inode)
 	op.addInode(ip)
-	util.DPrintf(1, "%d: GetInodeLocked %v\n", op.Atxn.Id(), ip)
+	util.DPrintf(1, "%p: GetInodeLocked %v\n", op.Atxn.Id(), ip)
 	return ip
 }
 

--- a/nfs_ops.go
+++ b/nfs_ops.go
@@ -78,7 +78,7 @@ func (nfs *Nfs) getShrink(fh nfstypes.Nfs_fh3) (*fstxn.FsTxn, *inode.Inode, nfst
 			err = nfstypes.NFS3ERR_SERVERFAULT
 			break
 		}
-		util.DPrintf(1, "getShrink: retry %d\n", op.Atxn.Id())
+		util.DPrintf(1, "getShrink: retry %p\n", op.Atxn.Id())
 	}
 	return op, ip, err
 }
@@ -352,7 +352,7 @@ func (nfs *Nfs) getAlloc(op *fstxn.FsTxn, dfh nfstypes.Nfs_fh3, name nfstypes.Fi
 			break
 		}
 
-		util.DPrintf(1, "getAlloc: retry %d\n", op.Atxn.Id())
+		util.DPrintf(1, "getAlloc: retry %p\n", op.Atxn.Id())
 	}
 	return op, dip, ip, err
 }

--- a/shrinker/shrinker.go
+++ b/shrinker/shrinker.go
@@ -47,7 +47,7 @@ func (shrinkst *ShrinkerSt) DoShrink(inum common.Inum) bool {
 		if ip == nil {
 			panic("shrink")
 		}
-		util.DPrintf(1, "%d: doShrink %v\n", op.Atxn.Id(), ip.Inum)
+		util.DPrintf(1, "%p: doShrink %v\n", op.Atxn.Id(), ip.Inum)
 		more = ip.Shrink(op.Atxn)
 		ok = op.Commit()
 		if !ok {


### PR DESCRIPTION
These are only used for debugging and have been replaced in DPrintf
statements with the pointer to the BufTxn object.