### PR TITLE
Do not destroy on shutdown by default

### DIFF
--- a/cmd/goose-nfsd/main.go
+++ b/cmd/goose-nfsd/main.go
@@ -92,7 +92,7 @@ func main() {
 	defer pmap_set_unset(nfstypes.NFS_PROGRAM, nfstypes.NFS_V3, port, false)
 
 	nfs := goose_nfs.MkNfsName(name, uint64(100*1000))
-	defer nfs.ShutdownNfsDestroy()
+	defer nfs.ShutdownNfs()
 
 	srv := rfc1057.MakeServer()
 	srv.RegisterMany(nfstypes.MOUNT_PROGRAM_MOUNT_V3_regs(nfs))


### PR DESCRIPTION
The current default behavior is to destroy the file system on shutdown, which made sense in the early days for debugging but probably is not intended any longer.